### PR TITLE
DO NOT MERGE Update Dockerfile complete build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
+FROM ibmjava:8-sdk AS builder
+LABEL maintainer="IBM Java Engineering at IBM Cloud"
+
+WORKDIR /app
+COPY . /app
+
+RUN apt-get update && apt-get install -y maven
+RUN mvn -N io.takari:maven:wrapper -Dmaven=3.5.0
+RUN ./mvnw install
+
 FROM ibmjava:8-sfj
 LABEL maintainer="IBM Java Engineering at IBM Cloud"
 
-COPY target/springmicroservice-1.0-SNAPSHOT.jar /app.jar
+COPY --from=builder /app/target/springmicroservice-1.0-SNAPSHOT.jar /app.jar
 
 ENV JAVA_OPTS=""
 ENTRYPOINT [ "sh", "-c", "java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.jar" ]


### PR DESCRIPTION
This PR is needed to run a complete Java Project build inside the dockerfile. Our Dockerfiles will no longer be able to count on the Toolchain or external environment to always compile the .jar file. We are updating this dockerfile to run a 2-stage Docker build, where the first stage downloads dependencies, and compiles the .jar, and then the second stage copies it over from the first container, and the first container is destroyed. This change is to work with the External OpenToolchain Toolchain templates that DevX is transitioning to.